### PR TITLE
disconnect the socket after show successful result

### DIFF
--- a/tcping/Tcping.m
+++ b/tcping/Tcping.m
@@ -46,6 +46,7 @@
     _speed = ([[NSDate date] timeIntervalSince1970]-[_startTime timeIntervalSince1970])*1000;
     [ConsoleIO printReulst:NO detail:self count:0 lossCount:0 min:@0 max:@0 avge:@0];
     dispatch_group_leave(_group);
+    [sock disconnect];
 }
 
 - (void)socketDidDisconnect:(GCDAsyncSocket *)sock withError:(NSError *)err {


### PR DESCRIPTION
Resolves #2 
Error "Socket closed by remote peer" will occur in more tests (at least 65 times).
After Debug, this error message points to the first socket object. The problem occurs when the socket connection is not actively closed after the connection is established.
The solution is actively disconnect the socket in the didConnectToHost callback.